### PR TITLE
bug fixes

### DIFF
--- a/languages/tribe-ext-ea-additional-options.pot
+++ b/languages/tribe-ext-ea-additional-options.pot
@@ -7,7 +7,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-05-25T18:31:10+02:00\n"
+"POT-Creation-Date: 2020-05-28T16:48:39+02:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: tribe-ext-ea-additional-options\n"
@@ -37,11 +37,11 @@ msgid "Additional Options"
 msgstr ""
 
 #: tribe-ext-ea-additional-options.php:74
-msgid "Delete Duplicate/Removed Events"
+msgid "Delete Duplicate/Removed Events for Scheduled Imports"
 msgstr ""
 
 #: tribe-ext-ea-additional-options.php:75
-msgid "By default, the Events Aggregator does not delete events that are removed from the import source. Check this box to delete these types of events. This will also remove duplicates in the case where the source changes the unique identifier for an event."
+msgid "Check this box to delete events that are removed from the import source. This will also remove duplicates in the case where the source changes the unique identifier for an event. ** NOTE: If your \"Event Update Authority\" setting is \"Do not re-import events...\", this setting will have no effect."
 msgstr ""
 
 #: tribe-ext-ea-additional-options.php:79
@@ -88,42 +88,42 @@ msgstr ""
 msgid "Retain all line breaks within event descirptions."
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:186
+#: tribe-ext-ea-additional-options.php:193
 msgid "Six months"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:187
+#: tribe-ext-ea-additional-options.php:194
 msgid "six months"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:190
+#: tribe-ext-ea-additional-options.php:197
 msgid "One year"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:191
+#: tribe-ext-ea-additional-options.php:198
 msgid "one year"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:194
+#: tribe-ext-ea-additional-options.php:201
 msgid "Two years"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:195
+#: tribe-ext-ea-additional-options.php:202
 msgid "two years"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:229
+#: tribe-ext-ea-additional-options.php:235
 msgid "Force Timezone:"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:233
+#: tribe-ext-ea-additional-options.php:239
 msgid "You can choose to change the timezones of all events in this import. The times will be modified to match the chosen timezone."
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:238
+#: tribe-ext-ea-additional-options.php:244
 msgid "Event Title Prefix:"
 msgstr ""
 
-#: tribe-ext-ea-additional-options.php:242
+#: tribe-ext-ea-additional-options.php:248
 msgid "Add text before the title of each event."
 msgstr ""

--- a/tribe-ext-ea-additional-options.php
+++ b/tribe-ext-ea-additional-options.php
@@ -348,7 +348,6 @@ if (
         }
         
         public function add_event_meta($event){
-            write_log($event);
             if(isset($event['EventEAImportId'])){
                 update_post_meta($event['ID'], '_tribe_aggregator_parent_record', $event['EventEAImportId']);
             }

--- a/tribe-ext-ea-additional-options.php
+++ b/tribe-ext-ea-additional-options.php
@@ -71,7 +71,7 @@ if (
                 ),
                 $this->opts_prefix . 'delete_duplicate_removed_events' => array(
                     'type' => 'radio',
-                    'label' => esc_html__('Delete Duplicate/Removed Events', 'tribe-ext-ea-additional-options'),
+                    'label' => esc_html__('Delete Duplicate/Removed Events for Scheduled Imports', 'tribe-ext-ea-additional-options'),
                     'tooltip' => esc_html__('Check this box to delete events that are removed from the import source. This will also remove duplicates in the case where the source changes the unique identifier for an event. ** NOTE: If your "Event Update Authority" setting is "Do not re-import events...", this setting will have no effect.', 'tribe-ext-ea-additional-options'),
                     'validation_type' => 'options',
                     'default' => 'no',

--- a/tribe-ext-ea-additional-options.php
+++ b/tribe-ext-ea-additional-options.php
@@ -229,7 +229,7 @@ if (
             $timezoneSelect .= '</select>';
             ?>
             <div class="tribe-default-settings">
-                <div class='tribe-dependent'  data-depends='#tribe-ea-field-origin' data-condition-not='["csv", "ics", "facebook-dev"]'>
+                <div class='tribe-dependent'  data-depends='#tribe-ea-field-origin' data-condition-not='["csv", "facebook-dev"]'>
                     <h4>Additional Options</h4>
                     <div class="tribe-refine tribe-active ">
                         <label for="tribe-ea-field-timezone"><?php esc_html_e('Force Timezone:', 'tribe-ext-ea-additional-options'); ?></label>

--- a/tribe-ext-ea-additional-options.php
+++ b/tribe-ext-ea-additional-options.php
@@ -120,7 +120,7 @@ if (
 
             add_action('admin_init', array($this, 'add_settings'));
 
-            $import_setting = tribe_get_option( 'tribe_aggregator_default_update_authority', Tribe__Events__Aggregator__Settings::$default_update_authority );
+            $import_setting = tribe_get_option('tribe_aggregator_default_update_authority', Tribe__Events__Aggregator__Settings::$default_update_authority);
             $deletionSetting = tribe_get_option($this->opts_prefix . 'delete_duplicate_removed_events');
             if ('retain' !== $import_setting && !empty($deletionSetting) && $deletionSetting !== 'no') {
                 add_action('save_post_tribe-ea-record', array($this, 'record_finalized'), 10, 2);
@@ -135,10 +135,7 @@ if (
                 add_filter('tribe_get_event_link', array($this, 'filter_event_link'), 100, 2);
             }
 
-            $lineBreakOpt = tribe_get_option($this->opts_prefix . 'retain_line_breaks');
-            if (tribe_is_truthy($lineBreakOpt)) {
-                add_filter('tribe_aggregator_event_translate_service_data_field_map', array($this, 'filter_service_data_field_map'));
-            }
+            add_filter('tribe_aggregator_event_translate_service_data_field_map', array($this, 'filter_service_data_field_map'));
 
             add_filter('tribe_aggregator_before_insert_event', array($this, 'filter_imported_event'), 10, 2);
             add_filter('tribe_aggregator_before_save_event', array($this, 'filter_imported_event'), 10, 2);
@@ -146,6 +143,8 @@ if (
             add_filter('tribe_aggregator_import_submit_meta', array($this, 'filter_import_meta'), 10, 2);
 
             add_filter('tribe_events_aggregator_tabs_new_handle_import_finalize', array($this, 'store_import_meta'), 10, 2);
+            
+            add_action('tribe_aggregator_after_insert_post', array($this, 'add_event_meta'));
         }
 
         /**
@@ -166,8 +165,8 @@ if (
                     'meta_query' => [
                         'relation' => 'AND',
                         [
-                            'key' => '_tribe_aggregator_source',
-                            'value' => $source,
+                            'key' => '_tribe_aggregator_parent_record',
+                            'value' => $post->post_parent,
                             'compare' => '='
                         ],
                         [
@@ -230,24 +229,26 @@ if (
             $timezoneSelect .= '</select>';
             ?>
             <div class="tribe-default-settings">
-                <h4>Additional Options</h4>
-                <div class="tribe-refine tribe-active">
-                    <label for="tribe-ea-field-timezone"><?php esc_html_e('Force Timezone:', 'tribe-ext-ea-additional-options'); ?></label>
-                    <?php echo $timezoneSelect; ?>
-                    <span
-                        class="tribe-bumpdown-trigger tribe-bumpdown-permanent tribe-bumpdown-nohover tribe-ea-help dashicons dashicons-editor-help"
-                        data-bumpdown="<?php echo esc_attr__('You can choose to change the timezones of all events in this import. The times will be modified to match the chosen timezone.', 'tribe-ext-ea-additional-options'); ?>"
-                        data-width-rule="all-triggers"
-                        ></span>
-                </div>
-                <div class="tribe-refine tribe-active">
-                    <label for="tribe-ea-field-prefix"><?php esc_html_e('Event Title Prefix:', 'tribe-ext-ea-additional-options'); ?></label>
-                    <input id="tribe-ea-field-prefix" name="aggregator[prefix]" class="tribe-ea-field tribe-ea-size-large" type="text" value="<?php echo esc_attr($prefixValue); ?>" />
-                    <span
-                        class="tribe-bumpdown-trigger tribe-bumpdown-permanent tribe-bumpdown-nohover tribe-ea-help dashicons dashicons-editor-help"
-                        data-bumpdown="<?php echo esc_attr__('Add text before the title of each event.', 'tribe-ext-ea-additional-options'); ?>"
-                        data-width-rule="all-triggers"
-                        ></span>
+                <div class='tribe-dependent'  data-depends='#tribe-ea-field-origin' data-condition-not='["csv", "ics", "facebook-dev"]'>
+                    <h4>Additional Options</h4>
+                    <div class="tribe-refine tribe-active ">
+                        <label for="tribe-ea-field-timezone"><?php esc_html_e('Force Timezone:', 'tribe-ext-ea-additional-options'); ?></label>
+                        <?php echo $timezoneSelect; ?>
+                        <span
+                            class="tribe-bumpdown-trigger tribe-bumpdown-permanent tribe-bumpdown-nohover tribe-ea-help dashicons dashicons-editor-help"
+                            data-bumpdown="<?php echo esc_attr__('You can choose to change the timezones of all events in this import. The times will be modified to match the chosen timezone.', 'tribe-ext-ea-additional-options'); ?>"
+                            data-width-rule="all-triggers"
+                            ></span>
+                    </div>
+                    <div class="tribe-refine tribe-active tribe-dependent">
+                        <label for="tribe-ea-field-prefix"><?php esc_html_e('Event Title Prefix:', 'tribe-ext-ea-additional-options'); ?></label>
+                        <input id="tribe-ea-field-prefix" name="aggregator[prefix]" class="tribe-ea-field tribe-ea-size-large" type="text" value="<?php echo esc_attr($prefixValue); ?>" />
+                        <span
+                            class="tribe-bumpdown-trigger tribe-bumpdown-permanent tribe-bumpdown-nohover tribe-ea-help dashicons dashicons-editor-help"
+                            data-bumpdown="<?php echo esc_attr__('Add text before the title of each event.', 'tribe-ext-ea-additional-options'); ?>"
+                            data-width-rule="all-triggers"
+                            ></span>
+                    </div>
                 </div>
             </div>
             <?php
@@ -269,10 +270,15 @@ if (
         }
 
         public function filter_service_data_field_map($fieldMap) {
-            if (isset($fieldMap['description'])) {
-                unset($fieldMap['description']);
+            $lineBreakOpt = tribe_get_option($this->opts_prefix . 'retain_line_breaks');
+            if (tribe_is_truthy($lineBreakOpt)) {
+                if (isset($fieldMap['description'])) {
+                    unset($fieldMap['description']);
+                }
+                $fieldMap['unsafe_description'] = 'post_content';
             }
-            $fieldMap['unsafe_description'] = 'post_content';
+            $fieldMap['start_date_utc'] = 'EventUTCStartDate';
+            $fieldMap['end_date_utc'] = 'EventUTCEndDate';
             return $fieldMap;
         }
 
@@ -284,6 +290,7 @@ if (
          */
         public function filter_imported_event($event, $record) {
             $meta = $record->meta;
+            $event['EventEAImportId'] = $record->post->post_parent;
             $lineBreakOpt = tribe_get_option($this->opts_prefix . 'retain_line_breaks');
             if (tribe_is_truthy($lineBreakOpt)) {
                 $event['post_content'] = str_replace(['\\n', '\n', "\n", "\\n"], '<br>', $event['post_content']);
@@ -292,21 +299,28 @@ if (
                 $event['post_title'] = $meta['prefix'] . ' ' . $event['post_title'];
             }
             if (!empty($meta['timezone'])) {
-                if (tribe_is_truthy($event['EventAllDay'])) {
+                if (!empty($event['EventAllDay']) && tribe_is_truthy($event['EventAllDay'])) {
                     $event['EventTimezone'] = $meta['timezone'];
                 } else {
                     $utcTimezone = new DateTimeZone("UTC");
                     $targetOffset = timezone_offset_get(timezone_open($meta['timezone']), new DateTime('now', $utcTimezone));
-                    $eventOffset = timezone_offset_get(timezone_open($event['EventTimezone']), new DateTime('now', $utcTimezone));
-                    try {
-                        $currTimezone = new DateTimeZone($event['EventTimezone']);
-                    } catch (\Exception $e) {
-                        $currTimezone = $utcTimezone;
+                    if(!isset($event['EventUTCStartDate'])){
+                        $event['EventTimezone'] = str_replace('UTC', 'Etc/GMT', $event['EventTimezone']);
+                        $eventOffset = timezone_offset_get(timezone_open($event['EventTimezone']), new DateTime('now', $utcTimezone));
+                        try {
+                            $currTimezone = new DateTimeZone($event['EventTimezone']);
+                        } catch (\Exception $e) {
+                            $currTimezone = $utcTimezone;
+                        }
+                        $currStartDateTime = new DateTime($event['EventStartDate'] . ' ' . $event['EventStartHour'] . ':' . $event['EventStartMinute'], $currTimezone);
+                        $currEndDateTime = new DateTime($event['EventEndDate'] . ' ' . $event['EventEndHour'] . ':' . $event['EventEndMinute'], $currTimezone);
+                        $offsetDiff = intval($targetOffset) - intval($eventOffset);
+                        $targetInterval = DateInterval::createFromDateString((string) $offsetDiff . ' seconds');
+                    }else{
+                        $currStartDateTime = new DateTime($event['EventUTCStartDate'], $utcTimezone);
+                        $currEndDateTime = new DateTime($event['EventUTCEndDate'], $utcTimezone);
+                        $targetInterval = DateInterval::createFromDateString((string) $targetOffset . ' seconds');
                     }
-                    $currStartDateTime = new DateTime($event['EventStartDate'] . ' ' . $event['EventStartHour'] . ':' . $event['EventStartMinute'], $currTimezone);
-                    $currEndDateTime = new DateTime($event['EventEndDate'] . ' ' . $event['EventEndHour'] . ':' . $event['EventEndMinute'], $currTimezone);
-                    $offsetDiff = intval($targetOffset) - intval($eventOffset);
-                    $targetInterval = DateInterval::createFromDateString((string) $offsetDiff . ' seconds');
                     $currStartDateTime->add($targetInterval);
                     $currEndDateTime->add($targetInterval);
                     $event['EventStartDate'] = $currStartDateTime->format('Y-m-d');
@@ -331,6 +345,13 @@ if (
         public function store_import_meta($record, $data) {
             $record->update_meta('prefix', empty($data['prefix']) ? null : $data['prefix'] );
             $record->update_meta('timezone', empty($data['timezone']) ? null : $data['timezone'] );
+        }
+        
+        public function add_event_meta($event){
+            write_log($event);
+            if(isset($event['EventEAImportId'])){
+                update_post_meta($event['ID'], '_tribe_aggregator_parent_record', $event['EventEAImportId']);
+            }
         }
 
     }


### PR DESCRIPTION
https://moderntribe.atlassian.net/browse/EXT-196

- Removed the Force Timezone and Prefix options from CSV and Facebook imports (since it's not tested on the Facebook extension)
- Instead of using the Import Source URL, I'm adding in the import record ID to the Event postmeta so that other import records can use the same source URL and it no interfere
- If UTC time is sent from EA, use it instead of using the timezone that is sent (fixes Meetup imports)
- Check if 'EventAllDay' exists before using (fixes PHP notices)