### PR TITLE
Force Timezone uses current time not the time of event

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Event Aggregator Extension: Additional Options ===
 Contributors: theeventscalendar
-Donate link: http://evnt.is/29
+Donate link: https://evnt.is/29
 Tags: events, calendar
 Requires at least: 5.8.6
-Tested up to: 6.1.1
+Tested up to: 6.3.2
 Requires PHP: 7.4
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -32,6 +32,12 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.4.2] 2023-11-01 =
+
+* Fix - Update so that DST changes are taken into account for time zone change calculations.
+* Fix - Make sure that the right event times are used for calculations when the source uses am/pm format.
+* Fix - Ensure that UTC times are used when they are available.
 
 = [1.4.1] 2023-06-24 =
 

--- a/src/Tribe/Modules/Options.php
+++ b/src/Tribe/Modules/Options.php
@@ -120,10 +120,18 @@ class Options {
 				return $event;
 			} else {
 				// If there is a meridian and it's "pm" then adjust times.
-				if ( strtolower( $event['EventStartMeridian'] ) === 'pm' && $event['EventStartHour'] < 12 ) {
+				if (
+					isset( $event['EventStartMeridian'] )
+					&& strtolower( $event['EventStartMeridian'] ) === 'pm'
+					&& $event['EventStartHour'] < 12
+				) {
 					$event['EventStartHour'] += 12;
 				}
-				if ( strtolower( $event['EventEndMeridian'] ) === 'pm' && $event['EventEndHour'] < 12 ) {
+				if (
+					isset( $event['EventEndMeridian'] )
+					&& strtolower( $event['EventEndMeridian'] ) === 'pm'
+					&& $event['EventEndHour'] < 12
+				) {
 					$event['EventEndHour'] += 12;
 				}
 

--- a/src/Tribe/Modules/Options.php
+++ b/src/Tribe/Modules/Options.php
@@ -99,7 +99,7 @@ class Options {
 			$timezone = str_replace( ' ', '_', trim( $meta['timezone'] ) );
 			$tz = new DateTimeZone( $timezone );
 
-			$target_offset = timezone_offset_get( $tz, new DateTime( 'now', $utc ) );
+			$target_offset = timezone_offset_get( $tz, new DateTime( $event['EventStartDate'], $utc ) );
 
 			$use_utc = empty( $event['EventUTCStartDate'] )
 			           && ! empty( $event['EventUTCStartDate'] )
@@ -121,7 +121,7 @@ class Options {
 				return $event;
 			} else {
 				$event['EventTimezone'] = str_replace( 'UTC', 'Etc/GMT', $event['EventTimezone'] );
-				$eventOffset            = timezone_offset_get( timezone_open( $event['EventTimezone'] ), new DateTime( 'now', $utc ) );
+				$eventOffset            = timezone_offset_get( timezone_open( $event['EventTimezone'] ), new DateTime( $event['EventStartDate'], $utc ) );
 				$currTimezone           = new DateTimeZone( $event['EventTimezone'] );
 				$start                  = new DateTime( $event['EventStartDate'] . ' ' . $event['EventStartHour'] . ':' . $event['EventStartMinute'], $currTimezone );
 				$end                    = new DateTime( $event['EventEndDate'] . ' ' . $event['EventEndHour'] . ':' . $event['EventEndMinute'], $currTimezone );

--- a/src/Tribe/Modules/Options.php
+++ b/src/Tribe/Modules/Options.php
@@ -101,8 +101,7 @@ class Options {
 
 			$target_offset = timezone_offset_get( $tz, new DateTime( $event['EventStartDate'], $utc ) );
 
-			$use_utc = empty( $event['EventUTCStartDate'] )
-			           && ! empty( $event['EventUTCStartDate'] )
+			$use_utc = ! empty( $event['EventUTCStartDate'] )
 			           && ! empty( $event['EventUTCEndDate'] );
 
 			$missing_event_details = empty( $event['EventStartDate'] )

--- a/src/Tribe/Modules/Options.php
+++ b/src/Tribe/Modules/Options.php
@@ -122,14 +122,14 @@ class Options {
 				// If there is a meridian and it's "pm" then adjust times.
 				if (
 					isset( $event['EventStartMeridian'] )
-					&& strtolower( $event['EventStartMeridian'] ) === 'pm'
+					&& 'pm' === strtolower( $event['EventStartMeridian'] )
 					&& $event['EventStartHour'] < 12
 				) {
 					$event['EventStartHour'] += 12;
 				}
 				if (
 					isset( $event['EventEndMeridian'] )
-					&& strtolower( $event['EventEndMeridian'] ) === 'pm'
+					&& 'pm' === strtolower( $event['EventEndMeridian'] )
 					&& $event['EventEndHour'] < 12
 				) {
 					$event['EventEndHour'] += 12;

--- a/src/Tribe/Modules/Options.php
+++ b/src/Tribe/Modules/Options.php
@@ -119,6 +119,14 @@ class Options {
 			} else if ( $missing_event_details ) {
 				return $event;
 			} else {
+				// If there is a meridian and it's "pm" then adjust times.
+				if ( strtolower( $event['EventStartMeridian'] ) === 'pm' && $event['EventStartHour'] < 12 ) {
+					$event['EventStartHour'] += 12;
+				}
+				if ( strtolower( $event['EventEndMeridian'] ) === 'pm' && $event['EventEndHour'] < 12 ) {
+					$event['EventEndHour'] += 12;
+				}
+
 				$event['EventTimezone'] = str_replace( 'UTC', 'Etc/GMT', $event['EventTimezone'] );
 				$eventOffset            = timezone_offset_get( timezone_open( $event['EventTimezone'] ), new DateTime( $event['EventStartDate'], $utc ) );
 				$currTimezone           = new DateTimeZone( $event['EventTimezone'] );

--- a/src/Tribe/Plugin.php
+++ b/src/Tribe/Plugin.php
@@ -19,7 +19,7 @@ class Plugin extends Service_Provider {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.4.1';
+	const VERSION = '1.4.2';
 
 	/**
 	 * Stores the base slug for the plugin.

--- a/tribe-ext-ea-additional-options.php
+++ b/tribe-ext-ea-additional-options.php
@@ -4,9 +4,9 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/ea-additional-options/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-ea-additional-options
  * Description:       Adds extra options to Event Aggregator settings and imports
- * Version:           1.4.1
+ * Version:           1.4.2
  * Author:            The Events Calendar
- * Author URI:        http://evnt.is/1971
+ * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       tribe-ext-ea-additional-options


### PR DESCRIPTION
[EXT-320]
https://stellarwp.atlassian.net/browse/EXT-320

The PR is aiming to fix three bugs:
1. There was a true/false check, which would always return false.
2. When changing the time zone, then for the time zone difference calculation the current time was used, and not the actual time of the event. Using the current time would not account for any DST changes.
3. In certain scenarios (saw it when using Other URL as a source and importing an event from our demo site), the event time would be formatted with a meridian, for example, 9 pm. That would take the start time wrongly as 9:00:00, while it should be 21:00:00

Screenshot of the respective setting:
https://www.dropbox.com/scl/fi/ve2dteztydc8glnjl166g/shot_231030_205829.jpg?rlkey=5c9h4fonqyqzltzeszs4xpf0j&dl=0